### PR TITLE
Add Liquibase Migration System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+
 .env
+!**/src/main/resources/liquibase.properties  # Liquibase configuration file
+
 ### STS ###
 .apt_generated
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
@@ -155,6 +159,15 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.liquibase</groupId>
+				<artifactId>liquibase-maven-plugin</artifactId>
+				<version>4.29.2</version>
+				<configuration>
+					<propertyFile>src/main/resources/liquibase.properties</propertyFile>
+					<changeLogFile>src/main/resources/db/changelog/db.changelog-master.xml</changeLogFile>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,6 @@ application.security.jwt.secret-key=${JWT_SECRET_KEY}
 application.security.jwt.expiration=${JWT_EXPIRATION_TIME}
 application.security.jwt.refresh-token.expiration=${REFRESH_EXPIRATION_TIME}
 
-
 # Server configuration
 # Datasource configuration
 spring.datasource.url=${DB_URL}
@@ -15,7 +14,16 @@ spring.datasource.driver-class-name=${DB_DRIVER}
 
 # Hibernate configuration
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
+
+# Liquibase configuration
+spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
+spring.liquibase.test-rollback-on-update=true
+spring.liquibase.show-summary=summary
+spring.liquibase.user=${DB_USER}
+spring.liquibase.password=${DB_PASS}
+spring.liquibase.url=${DB_URL}
+
 
 spring.jpa.properties.hibernate.dialect=${DB_DIALECT}
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/db/changelog/README.md
+++ b/src/main/resources/db/changelog/README.md
@@ -1,0 +1,98 @@
+# 📁 Liquibase Changelog Structure
+
+This directory contains all Liquibase migration files used to manage database schema changes in a modular and
+maintainable way.
+
+# 📦 Folder Structure
+
+`````
+db/changelog/
+├── user/
+│   └── v1.0__create-user-table.xml
+│   └── v1.0__add-name-of-constraint.xml
+├── entity/
+│   └── vX.action-entity-description.xml
+│   └── vX.Y__add-name-of-consraint.xml
+└── db.changelog-master.xml
+``````
+
+Each entity has its own folder containing changelogs relevant to that domain. This helps isolate changes and makes it
+easier to track schema evolution.
+
+# 🧩 Master Changelog
+
+The `db.changelog-master.xml` file includes all entity-specific changelogs:
+
+````
+<include file="db/changelog/entity/vX.Y__create-entity-table.xml" />
+<include file="db/changelog/ebtity/vX.Y__add-name-of-consraint.xml" />
+````
+
+# 🛠 Naming Conventions
+
+- **Files**: Use descriptive syntax `vX.Y__description.xml` for file names like `v1.0__create-user-table.xml` instead of
+  date-based names.
+
+- **ChangeSet IDs:** Prefer semantic IDs `action_entity_description` like `create-user-table` over timestamp-based ones.
+
+- **Authors:** Use your GitHub username or initials for traceability.
+
+# 🧪 Testing & Rollback
+
+Liquibase is configured to:
+
+- Validate changelogs on startup
+
+- Test rollback automatically
+
+- Show a summary of applied changes
+
+These settings are defined in application.properties:
+
+````
+spring.liquibase.enabled=true
+spring.liquibase.test-rollback-on-update=true
+spring.liquibase.show-summary=summary
+````
+
+# 🚀 Workflow Guide
+
+## First-Time Setup
+
+1. Copy `liquibase.properties.template` to `liquibase.properties`
+
+````
+  cp liquibase.properties.template liquibase.properties
+````
+
+2. Fill in your local DB credentials
+3. Never commit the actual properties file
+
+## 🧭 How to Add a New Migration
+
+* Create a new XML file in the appropriate folder.
+  `db/changelog/entity/v1.2__add-new-column.xml`
+* Define your <changeSet> with a unique ID and author.
+* Add the file to `db.changelog-master.xml` using `<include file="..."/>.`
+* Run the app to apply the migration or use the Liquibase CLI to apply changes manually.
+
+### 📜 Liquibase CLI Commands
+
+        ./mvnw liquibase:update	                                # Apply all pending changes
+        ./mvnw liquibase:rollback -Dliquibase.rollbackCount=1	# Rollback last change
+        ./mvnw liquibase:history	                            # View applied changesets
+        ./mvnw liquibase:validate	                            # Verify changelog integrity
+
+# 🔒 Rollback Best Practices
+
+Always include rollback blocks:
+
+```xml
+
+<changeSet id="create_user_table" author="youssef">
+    <createTable tableName="user">...</createTable>
+    <rollback>
+        <dropTable tableName="user"/>
+    </rollback>
+</changeSet>
+```

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+
+    <include file="/db/changelog/user/v1.0__create-user-17-08-changelog.xml"/>
+    <include file="/db/changelog/token/v1.0__create-token-17-08-changelog.xml"/>
+    <include file="/db/changelog/user/v1.0__create-user-history-17-08-changelog.xml"/>
+    <include file="/db/changelog/inverter/v1.0__create-inverter-17-08-changelog.xml"/>
+    <include file="/db/changelog/inverter/v1.0__create-inverter-history-17-08-changelog.xml"/>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/inverter/v1.0__create-inverter-17-08-changelog.xml
+++ b/src/main/resources/db/changelog/inverter/v1.0__create-inverter-17-08-changelog.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="create_inverter_table" author="youssef">
+
+        <createTable tableName="inverter">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_inverter"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="model" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manufacturer" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="inverter"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/inverter/v1.0__create-inverter-history-17-08-changelog.xml
+++ b/src/main/resources/db/changelog/inverter/v1.0__create-inverter-history-17-08-changelog.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="create_inverter_history_table" author="youssef">
+        <createTable tableName="inverter_history">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_inverterhistory"/>
+            </column>
+            <column name="original_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="synced" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="model" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manufacturer" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="inverter_history"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/token/v1.0__create-token-17-08-changelog.xml
+++ b/src/main/resources/db/changelog/token/v1.0__create-token-17-08-changelog.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="create_token_table" author="youssef">
+
+        <createTable tableName="token">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_token"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="token" type="VARCHAR(255)"/>
+            <column name="token_type" type="VARCHAR(255)"/>
+            <column name="revoked" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="UUID"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="token" constraintName="FK_TOKEN_ON_USER"
+                                 referencedColumnNames="id" referencedTableName="_user"/>
+
+        <addUniqueConstraint columnNames="token" constraintName="uc_token_token" tableName="token"/>
+
+        <rollback>
+            <dropTable tableName="token"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/user/v1.0__create-user-17-08-changelog.xml
+++ b/src/main/resources/db/changelog/user/v1.0__create-user-17-08-changelog.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="create_user_table" author="youssef">
+
+        <createTable tableName="_user">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk__user"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="firstname" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lastname" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="password" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(255)"/>
+            <column defaultValueBoolean="true" name="enabled" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint columnNames="email" constraintName="uc__user_email" tableName="_user"/>
+
+        <rollback>
+            <dropTable tableName="_user"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/user/v1.0__create-user-history-17-08-changelog.xml
+++ b/src/main/resources/db/changelog/user/v1.0__create-user-history-17-08-changelog.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="create_user_history_table" author="youssef">
+
+        <createTable tableName="user_history">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_userhistory"/>
+            </column>
+            <column name="original_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="synced" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="firstname" type="VARCHAR(255)"/>
+            <column name="lastname" type="VARCHAR(255)"/>
+            <column name="email" type="VARCHAR(255)"/>
+            <column name="password" type="VARCHAR(255)"/>
+            <column name="role" type="VARCHAR(255)"/>
+            <column name="enabled" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="disabled_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="user_history"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/liquibase.properties.template
+++ b/src/main/resources/liquibase.properties.template
@@ -1,0 +1,7 @@
+# liquibase.properties.template (template for Liquibase configuration)
+# Here you find how your liquibase.properties file should look like
+driver=YOUR_LIQUIBASE_DB_DRIVER
+url=YOUR_LIQUIBASE_DB_URL
+username=YOUR_LIQUIBASE_DB_USER
+password=YOUR_LIQUIBASE_DB_PASS
+changeLogFile=classpath:db/changelog/db.changelog-master.xml


### PR DESCRIPTION
📌 Liquibase Migration System Setup
🔍 Overview
This PR introduces a standardized database migration system using Liquibase, including:

Versioned changelog structure

Safe credential management

Rollback capabilities

Team documentation

📦 Changes Included
File/Folder | Purpose -- | -- db/changelog/ | New changelog directory structure liquibase.properties.template | Safe configuration template .gitignore | Added exclusion for liquibase.properties pom.xml | Liquibase Maven plugin configuration db/changelog/README.md | Migration guidelines
🛠 Setup Instructions
First-Time Setup
bash
# 1. Copy the template
cp liquibase.properties.template liquibase.properties
# 2. Configure your local DB

nano liquibase.properties


# 3. Validate changesets

./mvnw liquibase:validate

Database Migration
bash
# Apply pending changes

./mvnw liquibase:update

# Rollback last change

./mvnw liquibase:rollback -Dliquibase.rollbackCount=1

🌱 Changelog Structure
text
db/changelog/

├── domain/              # Business domains

│   ├── v1.0__create_[table].xml

│   └── v1.1__alter_[table].xml

└── db.changelog-master.xml  # Master changelog
✅ Testing Performed
Successful migration on local PostgreSQL

Rollback test for all changesets

Multi-developer environment validation

📜 Documentation Updates
See [db/changelog/README.md](https://./db/changelog/README.md) for:

Naming conventions

Migration authoring guide

Rollback procedures

⚠️ Breaking Changes
Requires Liquibase CLI (mvn liquibase:update) on first run

Existing manual DB changes should be converted to changelogs

📌 Liquibase Migration System Setup 🔍 Overview This PR introduces a standardized database migration system using Liquibase, including:
Versioned changelog structure

Safe credential management

Rollback capabilities

Team documentation

📦 Changes Included

db/changelog/ New changelog directory structure
liquibase.properties.template Safe configuration template
.gitignore Added exclusion for liquibase.properties
pom.xml Liquibase Maven plugin configuration
db/changelog/README.md Migration guidelines

🛠 Setup Instructions
First-Time Setup
bash

1. Copy the template`
cp liquibase.properties.template liquibase.properties`

2. Configure your local DB
nano liquibase.properties

3. Validate changesets
./mvnw liquibase:validate
Database Migration

Apply pending changes
./mvnw liquibase:update

Rollback last change
./mvnw liquibase:rollback -Dliquibase.rollbackCount=1
🌱 Changelog Structure
text
db/changelog/
├── domain/ # Business domains
│ ├── v1.0__create_[table].xml
│ └── v1.1__alter_[table].xml
└── db.changelog-master.xml # Master changelog
✅ Testing Performed
Successful migration on local PostgreSQL

Rollback test for all changesets

Multi-developer environment validation

📜 Documentation Updates
See [db/changelog/README.md](https://./db/changelog/README.md) for:

Naming conventions

Migration authoring guide

Rollback procedures

⚠️ Breaking Changes
Requires Liquibase CLI (mvn liquibase:update) on first run

Existing manual DB changes should be converted to changelogs