### PR TITLE
docs(liquibase): add alternative rollback syntax to README

### DIFF
--- a/src/main/resources/db/changelog/README.md
+++ b/src/main/resources/db/changelog/README.md
@@ -79,7 +79,8 @@ spring.liquibase.show-summary=summary
 ### 📜 Liquibase CLI Commands
 
         ./mvnw liquibase:update	                                # Apply all pending changes
-        ./mvnw liquibase:rollback -Dliquibase.rollbackCount=1	# Rollback last change
+        ./mvnw liquibase:rollback -Dliquibase.rollbackCount=1	# Rollback last change (1 changeSet)
+        ./mvnw liquibase:rollback --define liquibase.rollbackCount=1 # Alternative syntax if the one above don't work
         ./mvnw liquibase:history	                            # View applied changesets
         ./mvnw liquibase:validate	                            # Verify changelog integrity
 


### PR DESCRIPTION
Add alternative rollback syntax to liquibase's README