### PR TITLE
Bugfix/invertermapper impl

### DIFF
--- a/src/main/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapper.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapper.java
@@ -5,6 +5,8 @@ import com.youssef.GridPulse.domain.inverter.dto.InverterInput;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;
 import com.youssef.GridPulse.domain.inverter.entity.InverterHistory;
 import org.mapstruct.Mapper;
+import org.springframework.context.annotation.Primary;
 
+@Primary
 @Mapper(componentModel = "spring")
 public interface InverterMapper extends BaseMapper<Inverter, InverterHistory, InverterInput> {}


### PR DESCRIPTION
fix(dependency-injection): resolve InverterMapper bean ambiguity

- Added @Primary annotation to InverterMapper interface
- This resolves the Spring bean conflict where multiple candidates
  were found for InverterMapper injection
- Ensures clean constructor injection without qualifiers
- Maintains interface-based dependency injection principle