### PR TITLE
chore(validation): add spring-boot-starter-validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
# 🔧 Pull Request — Add Spring Boot Validation Dependency
## Summary
This PR adds the spring-boot-starter-validation dependency to enable data validation at the DTO and entity level using Jakarta Bean Validation annotations (@NotNull, @Size, etc.).

## Changes
- pom.xml: Added spring-boot-starter-validation dependency

- Prepared the project for annotation-based validation

- No changes to existing business logic

Why
- Standardize and centralize request data validation

- Reduce manual validation code

- Improve maintainability and readability

## How to Test
- Start the application

- Add a validation annotation to a DTO (e.g., @NotBlank on a field)

- Send an invalid request and verify that the expected validation error messages are returned