### PR TITLE
Refactor/base service crud hooks

### DIFF
--- a/src/main/java/com/youssef/GridPulse/domain/base/BaseService.java
+++ b/src/main/java/com/youssef/GridPulse/domain/base/BaseService.java
@@ -9,6 +9,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * To customize entity creation:
+ * - Override `beforeSave()` to resolve foreign keys or validate input.
+ * - Override `setRelationsInHistory()` to enrich history records with relation IDs.
+ * Do not override `setCreated`, `setUpdated`, or `setDeleted` unless lifecycle behavior must change.
+ */
 @RequiredArgsConstructor
 public abstract class BaseService<E extends BaseEntity, H extends BaseHistoryEntity, ID extends UUID, INPUT> {
 
@@ -21,6 +27,9 @@ public abstract class BaseService<E extends BaseEntity, H extends BaseHistoryEnt
         try{
         E entity = mapper.toEntity(input);
         entity.setId(null);
+
+        beforeSave(entity, input); // hook for FK resolution or validation
+
         E saved = repository.saveAndFlush(entity);
 
         H history = mapper.toHistory(saved);
@@ -114,21 +123,39 @@ public abstract class BaseService<E extends BaseEntity, H extends BaseHistoryEnt
 
 
     // --- Hooks/Helpers for history flags ---
-    protected abstract ID getId(E entity);
+    protected ID getId(E entity){
+       return (ID) entity.getId();
+    }
 
     protected void setCreated(H history, ID id) {
-        history.setId(null);
-        history.setOriginalId(id);
+        setHistoryIds(history, id);
         history.setCreatedRecord(true);
+        setRelationsInHistory(history, getEntityById(id));
     }
     protected void setUpdated(H history, ID id) {
-        history.setId(null);
-        history.setOriginalId(id);
+        setHistoryIds(history, id);
         history.setUpdatedRecord(true);
+        setRelationsInHistory(history, getEntityById(id));
     }
     protected void setDeleted(H history, ID id) {
+        setHistoryIds(history, id);
+        history.setDeletedRecord(true);
+        setRelationsInHistory(history, getEntityById(id));
+    }
+
+    protected void beforeSave(E entity, INPUT input) {
+        // Default implementation does nothing.
+        // Subclasses can override to resolve foreign keys or perform validation if any.
+        // This is called before the entity is saved for the first time.
+    }
+    protected void setRelationsInHistory(H history, E entity) {
+        // Default implementation does nothing.
+        // Subclasses can override to set relation IDs in history records.
+        // This is called when creating history records.
+    }
+
+    private void setHistoryIds(H history, ID id) {
         history.setId(null);
         history.setOriginalId(id);
-        history.setDeletedRecord(true);
     }
 }


### PR DESCRIPTION
# 🔧 Pull Request: Refactor BaseService with Lifecycle Hooks for CRUD Customization
## Summary
This PR introduces a lifecycle hook system to BaseService, enabling clean and scalable customization of entity persistence and history tracking. It removes the need to override setCreated, setUpdated, and setDeleted in each service, replacing them with targeted hooks.

## ✅ Changes Included
- Added beforeSave(E entity, INPUT input) hook for foreign key resolution and validation

- Added setRelationsInHistory(H history) hook for enriching history records with relation IDs

- Centralized setCreated, setUpdated, and setDeleted logic with internal helper setHistoryIds(...)

- Provided default implementation of getId(E entity) to reduce boilerplate in entity services

## 🧠 Benefits
- Reduces override surface in entity services

- Improves separation of concerns between lifecycle logic and customization

- Makes service layer more maintainable and extensible

- Prepares groundwork for future hooks like beforeDelete, afterUpdate, etc.

##📌 Next Steps
- Refactor existing services (e.g., DeviceService) to use new hooks

- Document hook usage for onboarding and contributor clarity