### PR TITLE
refactor(chore): move base folder from domain/ to common/ for shared …

### DIFF
--- a/src/main/java/com/youssef/GridPulse/common/base/BaseEntity.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/youssef/GridPulse/common/base/BaseHistoryEntity.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseHistoryEntity.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/youssef/GridPulse/common/base/BaseHistoryRepository.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseHistoryRepository.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/src/main/java/com/youssef/GridPulse/common/base/BaseMapper.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseMapper.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;

--- a/src/main/java/com/youssef/GridPulse/common/base/BaseResolver.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseResolver.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/youssef/GridPulse/common/base/BaseService.java
+++ b/src/main/java/com/youssef/GridPulse/common/base/BaseService.java
@@ -1,4 +1,4 @@
-package com.youssef.GridPulse.domain.base;
+package com.youssef.GridPulse.common.base;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/youssef/GridPulse/domain/device/entity/Device.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/entity/Device.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.entity;
 
-import com.youssef.GridPulse.domain.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseEntity;
 import com.youssef.GridPulse.domain.identity.user.entity.User;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;
 import jakarta.persistence.*;

--- a/src/main/java/com/youssef/GridPulse/domain/device/entity/DeviceHistory.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/entity/DeviceHistory.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.entity;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
 import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/youssef/GridPulse/domain/device/mapper/DeviceMapper.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/mapper/DeviceMapper.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.mapper;
 
-import com.youssef.GridPulse.domain.base.BaseMapper;
+import com.youssef.GridPulse.common.base.BaseMapper;
 import com.youssef.GridPulse.domain.device.dto.DeviceInput;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import com.youssef.GridPulse.domain.device.entity.DeviceHistory;

--- a/src/main/java/com/youssef/GridPulse/domain/device/repository/DeviceHistoryRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/repository/DeviceHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.repository;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryRepository;
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
 import com.youssef.GridPulse.domain.device.entity.DeviceHistory;
 
 import java.util.UUID;

--- a/src/main/java/com/youssef/GridPulse/domain/device/resolver/DeviceResolver.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/resolver/DeviceResolver.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.resolver;
 
-import com.youssef.GridPulse.domain.base.BaseResolver;
+import com.youssef.GridPulse.common.base.BaseResolver;
 import com.youssef.GridPulse.domain.device.dto.DeviceInput;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import com.youssef.GridPulse.domain.device.entity.DeviceHistory;

--- a/src/main/java/com/youssef/GridPulse/domain/device/service/DeviceService.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/service/DeviceService.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.device.service;
 
-import com.youssef.GridPulse.domain.base.BaseService;
+import com.youssef.GridPulse.common.base.BaseService;
 import com.youssef.GridPulse.domain.device.dto.DeviceInput;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import com.youssef.GridPulse.domain.device.entity.DeviceHistory;

--- a/src/main/java/com/youssef/GridPulse/domain/identity/token/Token.java
+++ b/src/main/java/com/youssef/GridPulse/domain/identity/token/Token.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.identity.token;
 
-import com.youssef.GridPulse.domain.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseEntity;
 import com.youssef.GridPulse.domain.identity.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/youssef/GridPulse/domain/identity/user/entity/User.java
+++ b/src/main/java/com/youssef/GridPulse/domain/identity/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.identity.user.entity;
 
-import com.youssef.GridPulse.domain.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseEntity;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import com.youssef.GridPulse.domain.identity.token.Token;
 import com.youssef.GridPulse.domain.identity.user.Role;

--- a/src/main/java/com/youssef/GridPulse/domain/identity/user/entity/UserHistory.java
+++ b/src/main/java/com/youssef/GridPulse/domain/identity/user/entity/UserHistory.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.identity.user.entity;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import lombok.*;

--- a/src/main/java/com/youssef/GridPulse/domain/identity/user/repository/UserHistoryRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/identity/user/repository/UserHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.identity.user.repository;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryRepository;
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
 import com.youssef.GridPulse.domain.identity.user.entity.UserHistory;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/youssef/GridPulse/domain/inverter/entity/Inverter.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/entity/Inverter.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.entity;
 
-import com.youssef.GridPulse.domain.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseEntity;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/youssef/GridPulse/domain/inverter/entity/InverterHistory.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/entity/InverterHistory.java
@@ -1,7 +1,7 @@
 package com.youssef.GridPulse.domain.inverter.entity;
 
 
-import com.youssef.GridPulse.domain.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapper.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapper.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.mapper;
 
-import com.youssef.GridPulse.domain.base.BaseMapper;
+import com.youssef.GridPulse.common.base.BaseMapper;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import com.youssef.GridPulse.domain.inverter.dto.InverterInput;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;

--- a/src/main/java/com/youssef/GridPulse/domain/inverter/repository/InverterHistoryRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/repository/InverterHistoryRepository.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.repository;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryRepository;
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
 import com.youssef.GridPulse.domain.inverter.entity.InverterHistory;
 
 import java.util.UUID;

--- a/src/main/java/com/youssef/GridPulse/domain/inverter/service/InverterService.java
+++ b/src/main/java/com/youssef/GridPulse/domain/inverter/service/InverterService.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.service;
 
-import com.youssef.GridPulse.domain.base.BaseService;
+import com.youssef.GridPulse.common.base.BaseService;
 import com.youssef.GridPulse.domain.inverter.dto.InverterInput;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;
 import com.youssef.GridPulse.domain.inverter.entity.InverterHistory;

--- a/src/main/java/com/youssef/GridPulse/domain/security/entity/SecurityKeys.java
+++ b/src/main/java/com/youssef/GridPulse/domain/security/entity/SecurityKeys.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.security.entity;
 
-import com.youssef.GridPulse.domain.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;

--- a/src/test/java/com/youssef/GridPulse/domain/base/BaseHistoryRepositoryTest.java
+++ b/src/test/java/com/youssef/GridPulse/domain/base/BaseHistoryRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.youssef.GridPulse.domain.base;
 
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;

--- a/src/test/java/com/youssef/GridPulse/domain/base/BaseMapperTest.java
+++ b/src/test/java/com/youssef/GridPulse/domain/base/BaseMapperTest.java
@@ -1,5 +1,8 @@
 package com.youssef.GridPulse.domain.base;
 
+import com.youssef.GridPulse.common.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseMapper;
 import org.junit.jupiter.api.*;
 
 import java.time.Instant;

--- a/src/test/java/com/youssef/GridPulse/domain/base/BaseResolverTest.java
+++ b/src/test/java/com/youssef/GridPulse/domain/base/BaseResolverTest.java
@@ -1,5 +1,8 @@
 package com.youssef.GridPulse.domain.base;
 
+import com.youssef.GridPulse.common.base.BaseEntity;
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
+import com.youssef.GridPulse.common.base.BaseService;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/youssef/GridPulse/domain/base/BaseServiceTest.java
+++ b/src/test/java/com/youssef/GridPulse/domain/base/BaseServiceTest.java
@@ -1,5 +1,6 @@
 package com.youssef.GridPulse.domain.base;
 
+import com.youssef.GridPulse.common.base.*;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapperTests.java
+++ b/src/test/java/com/youssef/GridPulse/domain/inverter/mapper/InverterMapperTests.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.mapper;
 
-import com.youssef.GridPulse.domain.base.BaseMapper;
+import com.youssef.GridPulse.common.base.BaseMapper;
 import com.youssef.GridPulse.domain.base.BaseMapperTest;
 import com.youssef.GridPulse.domain.inverter.dto.InverterInput;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;

--- a/src/test/java/com/youssef/GridPulse/domain/inverter/repository/InverterHistoryRepositoryTest.java
+++ b/src/test/java/com/youssef/GridPulse/domain/inverter/repository/InverterHistoryRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.youssef.GridPulse.domain.inverter.repository;
 
-import com.youssef.GridPulse.domain.base.BaseHistoryRepository;
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
 import com.youssef.GridPulse.domain.base.BaseHistoryRepositoryTest;
 import com.youssef.GridPulse.domain.inverter.entity.InverterHistory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
# 📦 Pull Request: Relocate Base Folder to Common Module
## Summary
Moved the base folder from domain/ to common/ to reflect its role as a shared foundation across modules. This improves clarity, reuse, and separation of concerns.

## 🔧 Changes Included
- Relocated base folder to common/

- Updated package declarations and imports accordingly

- No functional changes — purely structural refactor

## 🧠 Rationale
- base contains abstract entities, services, and mappers used across multiple domains

- Placing it in common/ makes its shared nature explicit

- Prepares the codebase for future modularization and microservice extraction