### PR TITLE
Development

### DIFF
--- a/src/main/java/com/youssef/GridPulse/domain/device/dto/DeviceInput.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/dto/DeviceInput.java
@@ -77,6 +77,9 @@ public record DeviceInput(
         UUID bmsId,
 
         @NotNull(message = "Meter ID is mandatory.")
-        UUID meterId
+        UUID meterId,
+
+        @NotNull(message = "Fleet ID is mandatory.")
+        UUID fleetId
 ) {
 }

--- a/src/main/java/com/youssef/GridPulse/domain/device/entity/Device.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/entity/Device.java
@@ -3,6 +3,7 @@ package com.youssef.GridPulse.domain.device.entity;
 import com.youssef.GridPulse.common.base.BaseEntity;
 import com.youssef.GridPulse.domain.bms.entity.Bms;
 import com.youssef.GridPulse.domain.device.enums.DeviceStatus;
+import com.youssef.GridPulse.domain.fleet.entity.Fleet;
 import com.youssef.GridPulse.domain.identity.user.entity.User;
 import com.youssef.GridPulse.domain.inverter.entity.Inverter;
 import com.youssef.GridPulse.domain.message.entity.Message;
@@ -70,6 +71,10 @@ public class Device extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "meter_id")
     private Meter meter;
+
+    @ManyToOne
+    @JoinColumn(name = "fleet_id", referencedColumnName = "id")
+    private Fleet fleet;
 
 
     @Transient

--- a/src/main/java/com/youssef/GridPulse/domain/device/entity/DeviceHistory.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/entity/DeviceHistory.java
@@ -42,5 +42,6 @@ public class DeviceHistory extends BaseHistoryEntity {
     private UUID inverterId;
     private UUID bmsId;
     private UUID meterId;
+    private UUID fleetId;
 
 }

--- a/src/main/java/com/youssef/GridPulse/domain/device/mapper/DeviceMapper.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/mapper/DeviceMapper.java
@@ -12,7 +12,9 @@ import org.springframework.context.annotation.Primary;
 @Primary
 @Mapper(componentModel = "spring",unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface DeviceMapper extends BaseMapper<Device, DeviceHistory, DeviceInput> {
+
     @Override
+    @Mapping(source = "fleet.id", target = "fleetId")
     @Mapping(source = "user.id", target = "userId")
     @Mapping(source = "operator.id", target = "operatorId")
     @Mapping(source = "inverter.id", target = "inverterId")
@@ -21,11 +23,12 @@ public interface DeviceMapper extends BaseMapper<Device, DeviceHistory, DeviceIn
     DeviceHistory toHistory(Device entity);
 
     @Override
-    @Mapping(source = "bmsId", target = "bms.id")
-    @Mapping(source = "inverterId", target = "inverter.id")
-    @Mapping(source = "meterId", target = "meter.id")
+    @Mapping(source = "fleetId", target = "fleet.id")
     @Mapping(source = "userId", target = "user.id")
     @Mapping(source = "operatorId", target = "operator.id")
+    @Mapping(source = "inverterId", target = "inverter.id")
+    @Mapping(source = "bmsId", target = "bms.id")
+    @Mapping(source = "meterId", target = "meter.id")
     Device toEntity(DeviceInput input);
 
 

--- a/src/main/java/com/youssef/GridPulse/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/repository/DeviceRepository.java
@@ -3,7 +3,9 @@ package com.youssef.GridPulse.domain.device.repository;
 import com.youssef.GridPulse.domain.device.entity.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface DeviceRepository extends JpaRepository<Device, UUID> {
+    List<Device> findByFleetId(UUID fleetId);
 }

--- a/src/main/java/com/youssef/GridPulse/domain/device/resolver/DeviceResolver.java
+++ b/src/main/java/com/youssef/GridPulse/domain/device/resolver/DeviceResolver.java
@@ -27,6 +27,11 @@ public class DeviceResolver extends BaseResolver<Device, DeviceHistory, UUID, De
     }
 
     @QueryMapping
+    public List<Device> getDevicesByFleetId(@Argument UUID fleetId) {
+        return service.getByFleetId(fleetId);
+    }
+
+    @QueryMapping
     public BatteryHealthStatus getHealthStatus(@Argument UUID deviceId) {
         return service.getHealthStatus(deviceId);
     }

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/dto/FleetInput.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/dto/FleetInput.java
@@ -1,0 +1,9 @@
+package com.youssef.GridPulse.domain.fleet.dto;
+
+public record FleetInput(
+        String name,
+        String location,
+        String owner,
+        String description
+) {}
+

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/entity/Fleet.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/entity/Fleet.java
@@ -1,0 +1,35 @@
+package com.youssef.GridPulse.domain.fleet.entity;
+
+import com.youssef.GridPulse.common.base.BaseEntity;
+import com.youssef.GridPulse.domain.device.entity.Device;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Entity
+public class Fleet extends BaseEntity {
+
+    private String name;
+
+    private String location;
+
+    private String owner; // customer, department, etc.
+
+    private String description;
+
+    @OneToMany(mappedBy = "fleet", fetch = FetchType.LAZY)
+    private List<Device> devices;
+}
+

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/entity/FleetHistory.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/entity/FleetHistory.java
@@ -1,0 +1,29 @@
+package com.youssef.GridPulse.domain.fleet.entity;
+
+import com.youssef.GridPulse.common.base.BaseHistoryEntity;
+import jakarta.persistence.Entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Entity
+public class FleetHistory extends BaseHistoryEntity {
+
+    private String name;
+
+    private String location;
+
+    private String owner; // optional: customer, department, etc.
+
+    private String description;
+
+}
+

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/mapper/FleetMapper.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/mapper/FleetMapper.java
@@ -1,0 +1,15 @@
+package com.youssef.GridPulse.domain.fleet.mapper;
+
+import com.youssef.GridPulse.common.base.BaseMapper;
+import com.youssef.GridPulse.domain.fleet.entity.Fleet;
+import com.youssef.GridPulse.domain.fleet.entity.FleetHistory;
+import com.youssef.GridPulse.domain.fleet.dto.FleetInput;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.context.annotation.Primary;
+
+@Primary
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FleetMapper extends BaseMapper<Fleet, FleetHistory, FleetInput> {
+}

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/repository/FleetHistoryRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/repository/FleetHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.youssef.GridPulse.domain.fleet.repository;
+
+import com.youssef.GridPulse.common.base.BaseHistoryRepository;
+import com.youssef.GridPulse.domain.fleet.entity.FleetHistory;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FleetHistoryRepository extends BaseHistoryRepository<FleetHistory, UUID> {
+}

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/repository/FleetRepository.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/repository/FleetRepository.java
@@ -1,0 +1,11 @@
+package com.youssef.GridPulse.domain.fleet.repository;
+
+import com.youssef.GridPulse.domain.fleet.entity.Fleet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FleetRepository extends JpaRepository<Fleet, UUID> {
+}

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/resolver/FleetResolver.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/resolver/FleetResolver.java
@@ -1,0 +1,81 @@
+package com.youssef.GridPulse.domain.fleet.resolver;
+
+import com.youssef.GridPulse.common.base.BaseResolver;
+
+import com.youssef.GridPulse.domain.fleet.dto.FleetInput;
+import com.youssef.GridPulse.domain.fleet.entity.Fleet;
+import com.youssef.GridPulse.domain.fleet.entity.FleetHistory;
+import com.youssef.GridPulse.domain.fleet.service.FleetService;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.UUID;
+
+@Controller
+@PreAuthorize("isAuthenticated()")
+public class FleetResolver extends BaseResolver<Fleet, FleetHistory, UUID, FleetInput> {
+
+    public FleetResolver(FleetService service) {
+        super(service);
+    }
+
+    @QueryMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<Fleet> getAllFleets() {
+        return super.getAll();
+    }
+
+    @QueryMapping
+    public Fleet getFleetById(@Argument UUID id) {
+        return super.getById(id);
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Fleet createFleet(@Argument FleetInput input) {
+        return super.create(input);
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Fleet updateFleet(@Argument UUID id, @Argument FleetInput input) {
+        return super.update(id, input);
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public boolean deleteFleet(@Argument UUID id) {
+        return super.delete(id);
+    }
+
+    // History methods
+    @QueryMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<FleetHistory> getFleetHistory(@Argument UUID originalId) {
+        return super.getHistory(originalId);
+    }
+
+    @QueryMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<FleetHistory> getAllFleetHistory() {
+        return super.getAllHistory();
+    }
+
+    @QueryMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public FleetHistory getFleetHistoryById(@Argument UUID historyId) {
+        return super.getHistoryById(historyId);
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public Boolean markFleetHistorySynced(@Argument UUID id) {
+        return super.markHistorySynced(id);
+    }
+
+
+}

--- a/src/main/java/com/youssef/GridPulse/domain/fleet/service/FleetService.java
+++ b/src/main/java/com/youssef/GridPulse/domain/fleet/service/FleetService.java
@@ -1,0 +1,19 @@
+package com.youssef.GridPulse.domain.fleet.service;
+
+import com.youssef.GridPulse.common.base.BaseService;
+import com.youssef.GridPulse.domain.fleet.entity.Fleet;
+import com.youssef.GridPulse.domain.fleet.entity.FleetHistory;
+import com.youssef.GridPulse.domain.fleet.dto.FleetInput;
+import com.youssef.GridPulse.domain.fleet.mapper.FleetMapper;
+import com.youssef.GridPulse.domain.fleet.repository.FleetHistoryRepository;
+import com.youssef.GridPulse.domain.fleet.repository.FleetRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class FleetService extends BaseService<Fleet, FleetHistory, UUID, FleetInput> {
+    public FleetService(FleetRepository repo, FleetHistoryRepository historyRepo, FleetMapper mapper) {
+        super(repo, historyRepo, mapper);
+    }
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -30,4 +30,6 @@
     <include file="/db/changelog/device/v1.0__add-ip-and-software-update-time-to-device-tables-10-10-changelog.xml"/>
     <include file="db/changelog/message/v1.0__add-fields-to-message-tables-10-10-changelog.xml"/>
     <include file="db/changelog/device/v1.0__alter-device-soh-column-14-10-changelog.xml"/>
+    <include file="db/changelog/fleet/v1.0__create-fleet-tables-15-10-changelog.xml"/>
+    <include file="db/changelog/device/v1.0__add-fleetId-to-device-tables-16-10-changelog.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/device/v1.0__add-fleetId-to-device-tables-16-10-changelog.xml
+++ b/src/main/resources/db/changelog/device/v1.0__add-fleetId-to-device-tables-16-10-changelog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="add_fleet_id_to_device_tables" author="youssef">
+        <addColumn tableName="device">
+            <column name="fleet_id" type="UUID"/>
+        </addColumn>
+
+        <addForeignKeyConstraint baseColumnNames="fleet_id" baseTableName="device" constraintName="FK_DEVICE_ON_FLEET"
+                                 referencedColumnNames="id" referencedTableName="fleet"/>
+
+        <addColumn tableName="device_history">
+            <column name="fleet_id" type="UUID"/>
+        </addColumn>
+
+        <comment>
+            Note: Existing records in the 'device' and 'device_history' tables will have NULL in the new 'fleet_id' column.
+            Future application logic should ensure that new records include a valid 'fleet_id'.
+            Consider adding a default value or updating existing records if necessary.
+        </comment>
+
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="device" constraintName="FK_DEVICE_ON_FLEET"/>
+            <dropColumn tableName="device" columnName="fleet_id"/>
+            <dropColumn tableName="device_history" columnName="fleet_id"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/fleet/v1.0__create-fleet-tables-15-10-changelog.xml
+++ b/src/main/resources/db/changelog/fleet/v1.0__create-fleet-tables-15-10-changelog.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="create_fleet_table" author="youssef">
+        <createTable tableName="fleet">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_fleet"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="location" type="VARCHAR(255)"/>
+            <column name="owner" type="VARCHAR(255)"/>
+            <column name="description" type="VARCHAR(255)"/>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="fleet"/>
+        </rollback>
+
+        <comment>
+            This table stores information about fleets, a swarm of devices managed together.
+            It includes metadata for auditing and tracking changes, ensuring data integrity and traceability.
+        </comment>
+    </changeSet>
+
+    <changeSet id="create_fleet_history_table" author="youssef">
+        <createTable tableName="fleet_history">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_fleetHistory"/>
+            </column>
+            <column name="original_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deleted_record" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="synced" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="DATETIME"/>
+            <column name="created_by" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_by" type="VARCHAR(255)"/>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="location" type="VARCHAR(255)"/>
+            <column name="owner" type="VARCHAR(255)"/>
+            <column name="description" type="VARCHAR(255)"/>
+        </createTable>
+
+        <rollback>
+            <dropTable tableName="fleet_history"/>
+        </rollback>
+
+        <comment>
+            This table stores information about fleets auditing history for tracking changes over time.
+            It includes metadata for auditing and tracking changes, ensuring data integrity and traceability.
+        </comment>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -12,12 +12,19 @@ type Query {
     getInverterHistoryById(historyId: ID!): InverterHistory!
     getInverterHistory(originalId: ID!): [InverterHistory!]!
 
+    getAllFleets: [Fleet!]!
+    getFleetById(id: ID!): Fleet!
+    getAllFleetHistory: [FleetHistory!]!
+    getFleetHistoryById(historyId: ID!): FleetHistory!
+    getFleetHistory(originalId: ID!): [FleetHistory!]!
+
     getAllDevices: [Device!]!
     getDeviceById(id: ID!): Device!
     getAllDeviceHistory: [DeviceHistory!]!
     getDeviceHistoryById(historyId: ID!): DeviceHistory!
     getDeviceHistory(originalId: ID!): [DeviceHistory!]!
     getHealthStatus(deviceId: ID!): BatteryHealthStatus!
+    getDevicesByFleetId(fleetId: ID!): [Device!]!
 
     getAllBms: [Bms!]!
     getBmsById(id: ID!): Bms!
@@ -50,6 +57,10 @@ type Mutation {
     deleteInverter(id: ID!): Boolean
     markInverterHistorySynced(id: ID!): Boolean!
 
+    createFleet(input: FleetInput!): Fleet!
+    updateFleet(id: ID!, input: FleetInput!): Fleet!
+    deleteFleet(id: ID!): Boolean!
+    markFleetHistorySynced(id: ID!): Boolean!
 
     createDevice(input: DeviceInput!): Device
     updateDevice(id: ID!, input: DeviceInput!): Device
@@ -165,7 +176,7 @@ type Device implements Auditable {
     id: ID!
     name: String!
     soc: Float!
-    soh: String!
+    soh: Float!
     batteryChemistry: String!
     cycles: Int!
     gpsLat: Float
@@ -183,6 +194,7 @@ type Device implements Auditable {
 
     # Relations
 
+    fleet: Fleet!
     inverter: Inverter!
     operator: User!
     user: User!
@@ -222,6 +234,21 @@ type Meter implements Auditable {
     model: String
     manufacturer: String
     version: String
+
+    # Auditable fields
+    createdBy: String!
+    updatedBy: String
+    createdAt: String!
+    updatedAt: String
+    source: Source!
+}
+
+type Fleet implements Auditable{
+    id: ID!
+    name: String!
+    location: String
+    owner: String
+    description: String
 
     # Auditable fields
     createdBy: String!
@@ -272,12 +299,32 @@ type InverterHistory implements AuditableHistory {
     synced: Boolean!
 }
 
+type FleetHistory implements AuditableHistory{
+    id: ID!
+    originalId: ID!
+    name: String!
+    location: String
+    owner: String
+    description: String
+
+    # Auditable fields
+    createdBy: String!
+    updatedBy: String
+    createdAt: String!
+    updatedAt: String
+    source: Source!
+    createdRecord: Boolean!
+    updatedRecord: Boolean!
+    deletedRecord: Boolean!
+    synced: Boolean!
+}
+
 type DeviceHistory implements AuditableHistory {
     id: ID!
     originalId: ID!
     name: String!
     soc: Float!
-    soh: String!
+    soh: Float!
     batteryChemistry: String!
     cycles: Int!
     gpsLat: Float
@@ -292,7 +339,7 @@ type DeviceHistory implements AuditableHistory {
     manufacturer: String!
 
     # Relations
-
+    fleetId: ID!
     inverterId: ID!
     operatorId: ID!
     userId: ID!
@@ -373,10 +420,17 @@ input InverterInput {
     manufacturer: String
 }
 
+input FleetInput {
+    name: String!
+    location: String
+    owner: String
+    description: String
+}
+
 input DeviceInput {
     name: String
     soc: Float
-    soh: String
+    soh: Float
     batteryChemistry: String
     cycles: Int
     gpsLat: Float
@@ -392,6 +446,8 @@ input DeviceInput {
     swUpdateTime: String
     ip: String
 
+    # Relations
+    fleetId: ID!
     inverterId: ID!
     operatorId: ID!
     userId: ID!


### PR DESCRIPTION
🚀 Feature: Fleet Management
Summary
This PR introduces the Fleet entity to support logical grouping of devices across locations, customers, or operational units. It includes full CRUD operations, history tracking, and GraphQL integration.

✅ Changes
Domain
Added Fleet entity with fields: name, location, owner, description

Linked Device to Fleet via @ManyToOne relationship

Input & GraphQL
Created FleetInput record for mutation payloads

Added GraphQL schema types and inputs for Fleet

Exposed createFleet, getAllFleets, updateFleet, deleteFleet mutations and queries

History & Audit
Added FleetHistory entity for tracking changes

Integrated with BaseService and BaseResolver for auditability

Migrations
Added two Liquibase changesets:

fleet table

fleet_history table

🧠 Notes
FleetHistory tracks metadata changes only — devices are tracked separately via DeviceHistory

getAllFleets() returns an empty list if no fleets exist, ensuring GraphQL non-null contract

fleetId is now available in DeviceInput and populated during device creation

📌 Next Steps
Wire fleet filtering into dashboard views

Add getDevicesByFleet(fleetId) query

Consider FleetStatus enum for lifecycle management