### PR TITLE
infra(ci-docker): remove ci/ci-docker branch trigger from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: GridPulse CI/CD Pipeline
 
 on:
   push:
-    branches: [ "master", "development", "ci/ci-docker" ]
+    branches: [ "master", "development" ]
   pull_request:
     branches: [ "master", "development" ]
 


### PR DESCRIPTION
add Docker image build & push workflow
- extended CI pipeline to build and push backend image to Docker Hub
- integrated docker/login-action, setup-buildx, and build-push-action
- aligned docker-compose service with pushed image tag (ammysf/gridpulse-cloud-backend:latest)