### PR TITLE
Actuator Integration: Custom Endpoints + Secure Exposure

### DIFF
--- a/src/main/java/com/youssef/GridPulse/configuration/security/ActuatorSecurityConfig.java
+++ b/src/main/java/com/youssef/GridPulse/configuration/security/ActuatorSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.youssef.GridPulse.configuration.security;
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class ActuatorSecurityConfig {
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorSecurity(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher(EndpointRequest.toAnyEndpoint()) // matches ONLY actuator endpoints and isolate it from other security configs (No JWT here)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable)
+
+                .build();
+    }
+}
+


### PR DESCRIPTION
✅ PR Description

This PR completes task #153, integrating Spring Boot Actuator with custom operational endpoints and securing their exposure.

## Security Adjustments

Actuator exposure required refining the existing Spring Security configuration.
The following updates were applied:

Whitelisted operational endpoints to avoid authentication failures on health checks and monitoring tools:

- /actuator

- /actuator/**

- GraphQL endpoints remain fully public to support the current JWT flow until the refactor (task #154) is completed.

- Stateless session policy preserved to ensure compatibility with JWT authentication.

- Ensured that no sensitive management endpoint is exposed in production, relying on profile-based configuration:

    - dev → open Actuator for debugging

    - prod → restrict Actuator to minimal safe endpoints (health, info, prometheus, and custom gridpulseinfo only)

This ensures Actuator operates correctly on both management ports while maintaining a secure perimeter around the application.