### PR TITLE
Remove unused WebFlux dependency from backend build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
             <artifactId>hibernate-types-60</artifactId>
             <version>2.21.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <!-- Database -->
         <dependency>


### PR DESCRIPTION
This PR removes the unnecessary spring-boot-starter-webflux dependency from the backend pom.xml.
The project is fully based on Spring MVC and does not use any reactive components, so keeping WebFlux adds unnecessary weight and increases the risk of conflicting auto-configurations.

## Changes
- Removed spring-boot-starter-webflux from pom.xml
- Ensured the application builds correctly using Spring MVC only

## Why

- Reduces build footprint
- Avoids potential WebFlux/MVC auto-config conflicts
- We don't need any reactive programming features 
- Keeps the dependency tree aligned with actual project needs

## Testing

- Application builds successfully
- All APIs work as expected in local dev environment
- No regressions detected