### PR TITLE
chore(dependabot): restrict updates to allowed major versions for Angular and Temurin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,10 @@ updates:
       - "ci/cd"
       - "dependencies"
       - "dependabot"
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        versions:
+          - ">=18"
     commit-message:
       prefix: "deps-docker-backend"
 
@@ -72,6 +76,11 @@ updates:
       - "ci/cd"
       - "dependencies"
       - "dependabot"
+
+    ignore:
+      - dependency-name: "@angular/*"
+        versions:
+          - ">=20"
     commit-message:
       prefix: "deps-docker-frontend"
 


### PR DESCRIPTION

- Added ignore rules to prevent Dependabot from proposing upgrades beyond:
    - Java 17 
    - Angular 19 
- Ensures version stability across frontend and backend
- Avoids unnecessary PR spam and enforces project’s supported stack