### PR TITLE
Development: Implement buildx caching for backend and frontend images --> faster builds in PRs merging

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -57,6 +57,8 @@ jobs:
           tags: |
             ammysf/gridpulse-backend:latest
             ammysf/gridpulse-backend:${{ github.sha }}
+          cache-from: type=registry,ref=ammysf/gridpulse-backend:cache
+          cache-to: type=registry,ref=ammysf/gridpulse-backend:cache,mode=max,inline=true
 
   # ================================
   #     FRONTEND DOCKER BUILD
@@ -91,3 +93,5 @@ jobs:
           tags: |
             ammysf/gridpulse-frontend:latest
             ammysf/gridpulse-frontend:${{ github.sha }}
+          cache-from: type=registry,ref=ammysf/gridpulse-frontend:cache
+          cache-to: type=registry,ref=ammysf/gridpulse-frontend:cache,mode=max,inline=true


### PR DESCRIPTION
Enable Buildx **inline** caching for backend & frontend

Add Buildx inline caching to backend & frontend Docker builds to speed up repeated CI builds. Uses `cache-from` and `cache-to: inline`.

No breaking changes.

- [ ] Backend and frontend builds use inline caching.
- [ ]  Subsequent builds display cache hits in logs.
- [ ]  No breaking changes introduced to Docker image push workflow.