### PR TITLE
Add SonarQube analysis job to backend CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -55,24 +55,32 @@ jobs:
   sonarqube-scan:
     name: SonarQube Analysis
     runs-on: ubuntu-latest
-    needs: maven-build-jar # Wait for the #1 job to end
+    needs: maven-build-jar
 
     steps:
       - name: Step 1 - Checkout
         uses: actions/checkout@v6
 
-      - name: Step 2 - Analyze with SonarQube
+      - name: Step 2 - Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
 
+      - name: Step 3 - Build backend (required for Sonar)
+        working-directory: backend
+        run: mvn clean compile
+
+      - name: Step 4 - SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-
-          args:
+          projectBaseDir: backend
+          args: >
             -Dsonar.projectKey=Ammari-Youssef_GridPulse
             -Dsonar.organization=ammari-youssef
-            -Dsonar.projectBaseDir=./backend
             -Dsonar.sources=src/main/java
             -Dsonar.tests=src/test/java
             -Dsonar.java.binaries=target/classes
-            -Dsonar.junit.reportPaths=target/surefire-reports

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -51,3 +51,27 @@ jobs:
         run: |
           echo "Target folder content:"
           ls -la backend/target
+
+  sonarqube-scan:
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+    needs: maven-build-jar # Wait for the #1 job to end
+
+    steps:
+      - name: Step 1 - Checkout
+        uses: actions/checkout@v6
+
+      - name: Step 2 - Analyze with SonarQube
+
+        uses: SonarSource/sonarqube-scan-action@v7.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+
+          args:
+            -Dsonar.projectKey=Ammari-Youssef_GridPulse
+            -Dsonar.projectBaseDir=./backend
+            -Dsonar.sources=src/main/java
+            -Dsonar.tests=src/test/java
+            -Dsonar.java.binaries=target/classes
+            -Dsonar.junit.reportPaths=target/surefire-reports

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Step 3 - Build backend (required for Sonar)
         working-directory: backend
-        run: mvn clean compile
+        run: mvn clean verify
 
       - name: Step 4 - SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v7.0.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,6 +70,7 @@ jobs:
 
           args:
             -Dsonar.projectKey=Ammari-Youssef_GridPulse
+            -Dsonar.organization=ammari-youssef
             -Dsonar.projectBaseDir=./backend
             -Dsonar.sources=src/main/java
             -Dsonar.tests=src/test/java

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,7 @@
         <lombok.version>1.18.36</lombok.version>
         <jacoco.version>0.8.14</jacoco.version>
         <liquibase.version>4.29.2</liquibase.version>
+        <sonar.organization>ammari-youssef</sonar.organization>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This PR introduces a new GitHub Actions job for SonarQube analysis of the Spring Boot backend:

- **Job Name:** `sonarqube-scan`  
- Runs after the Maven build and test job (`maven-build-jar`).  
- Uses the official SonarSource GitHub Action (`SonarSource/sonarqube-scan-action@v7.0.0`).  
- Pulls the `SONAR_TOKEN` from GitHub secrets for authentication.  
- Configured project key: `Ammari-Youssef_GridPulse`.  
- Base directory for analysis: `./backend`.  

## Notes
- JaCoCo coverage is already integrated in `pom.xml` and generates reports.  
- Coverage enforcement via `<jacoco-check>` is currently commented to prevent build failures.  
