### PR TITLE
Development: chore(frontend): introduce shared MaterialModule

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -123,6 +123,11 @@
       }
     }
   },
+  "schematics": {
+    "@schematics/angular:component": {
+      "standalone": false
+    }
+  },
   "cli": {
     "schematicCollections": [
       "angular-eslint"

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -1,16 +1,33 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-// Angular Material Modules
-import { MatButtonModule } from '@angular/material/button';
-import { MatCardActions, MatCardModule } from '@angular/material/card';
-import { ForbiddenComponent } from './pages/forbidden/forbidden.component';
-import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { RouterModule } from '@angular/router';
+
+// Shared Components & Modules
+import { MaterialModule } from '@shared/ui/material/material.module';
+import { ForbiddenComponent } from '@shared/pages/forbidden/forbidden.component';
+import { NotFoundComponent } from '@shared/pages/not-found/not-found.component';
 
 @NgModule({
   declarations: [ForbiddenComponent, NotFoundComponent],
-  exports: [ForbiddenComponent, NotFoundComponent],
-  imports: [CommonModule, MatCardModule, MatCardActions, MatButtonModule, RouterModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+
+    // Material
+    MaterialModule,
+  ],
+  exports: [
+    // Angular
+    CommonModule,
+    RouterModule,
+
+    // Material
+    MaterialModule,
+
+    // Shared Components
+    ForbiddenComponent,
+    NotFoundComponent,
+
+  ],
 })
 export class SharedModule {}

--- a/frontend/src/app/shared/ui/material/material.module.ts
+++ b/frontend/src/app/shared/ui/material/material.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+
+// Angular Material
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+const MATERIAL_MODULES = [
+  MatButtonModule,
+  MatCardModule,
+  MatIconModule,
+  MatFormFieldModule,
+  MatInputModule,
+  MatToolbarModule,
+  MatSnackBarModule,
+];
+
+@NgModule({
+  imports: [ ...MATERIAL_MODULES ],
+  exports: [ ...MATERIAL_MODULES ],
+})
+export class MaterialModule {}


### PR DESCRIPTION
- Introduce MaterialModule to centralize Angular Material imports
- Export MaterialModule via SharedModule
- Fix template errors related to missing Angular Material components
- Prepare codebase for feature-based NgModule architecture
